### PR TITLE
Fix cURL examples for download endpoints

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start"],
+      "port": 3030
+    }
+  ]
+}

--- a/src/components/RequestFormatters.ts
+++ b/src/components/RequestFormatters.ts
@@ -10,6 +10,19 @@ export interface RequestData {
   body?: any;
 }
 
+export interface ResponseData {
+  status?: number;
+  headers?: { [key: string]: string };
+  body?: any;
+}
+
+function getDownloadFilename(response?: ResponseData): string | null {
+  const disposition = response?.headers?.["Content-Disposition"];
+  if (!disposition || !/attachment/i.test(disposition)) return null;
+  const match = disposition.match(/filename\s*=\s*"?([^"]+)"?/i);
+  return match ? match[1] : null;
+}
+
 /**
  * Formats a request as a plain HTTP request
  */
@@ -36,28 +49,34 @@ export function formatHttpRequest(request: RequestData): string {
 /**
  * Formats a request as a cURL command
  */
-export function formatCurlCommand(request: RequestData): string {
+export function formatCurlCommand(request: RequestData, response?: ResponseData): string {
   const { request_method, path, body } = request;
-  const hasBody = body && Object.keys(body).length > 0 && ['POST', 'PUT', 'PATCH'].includes(request_method.toUpperCase());
-  
+  const method = request_method.toUpperCase();
+  const hasBody = body && Object.keys(body).length > 0 && ['POST', 'PUT', 'PATCH'].includes(method);
+  const downloadFilename = getDownloadFilename(response);
+
   // Extract common path parameters as variables
   let curlCommand = '';
   if (path.includes(':dossier_id')) {
     curlCommand += `DOSSIER_ID="your_dossier_id"\n`;
   }
-  
+
   // Replace path parameters with variable references
   let urlPath = path.replace(':dossier_id', '$DOSSIER_ID');
   const url = `${BASE_URL}${urlPath}`;
-  
-  curlCommand += `curl -X ${request_method.toUpperCase()} "${url}" \\\n`;
+
+  const flags: string[] = [];
+  if (method !== 'GET') flags.push(`-X ${method}`);
+  if (downloadFilename) flags.push('-L', `-o "${downloadFilename}"`);
+
+  curlCommand += `curl ${flags.length ? flags.join(' ') + ' ' : ''}"${url}" \\\n`;
   curlCommand += `  -u "username:password"`;
-  
+
   if (hasBody) {
     curlCommand += ` \\\n  -H "Content-Type: application/json"`;
     curlCommand += ` \\\n  -d '${JSON.stringify(body, null, 2)}'`;
   }
-  
+
   return curlCommand;
 }
 

--- a/src/components/RequestTabs.tsx
+++ b/src/components/RequestTabs.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import { formatHttpRequest, formatCurlCommand, formatPowerShellCommand, RequestData } from './RequestFormatters';
+import { formatHttpRequest, formatCurlCommand, formatPowerShellCommand, RequestData, ResponseData } from './RequestFormatters';
 import styles from './RequestTabs.module.css';
 
 interface RequestTabsProps {
   request: RequestData;
+  response?: ResponseData;
 }
 
 type TabType = 'http' | 'curl' | 'powershell';
@@ -15,7 +16,7 @@ const TABS = [
   { id: 'powershell' as TabType, label: 'PowerShell', language: 'powershell' },
 ];
 
-export const RequestTabs: React.FC<RequestTabsProps> = ({ request }) => {
+export const RequestTabs: React.FC<RequestTabsProps> = ({ request, response }) => {
   const [activeTab, setActiveTab] = useState<TabType>('http');
 
   const getFormattedRequest = (tabType: TabType): string => {
@@ -23,7 +24,7 @@ export const RequestTabs: React.FC<RequestTabsProps> = ({ request }) => {
       case 'http':
         return formatHttpRequest(request);
       case 'curl':
-        return formatCurlCommand(request);
+        return formatCurlCommand(request, response);
       case 'powershell':
         return formatPowerShellCommand(request);
       default:

--- a/src/components/Snapshot.tsx
+++ b/src/components/Snapshot.tsx
@@ -38,7 +38,7 @@ type Snapshot = {
 export const Request = ({snapshot}) => {
   return <>
     <h3>Sample request</h3>
-    <RequestTabs request={snapshot.request} />
+    <RequestTabs request={snapshot.request} response={snapshot.response} />
   </>
 }
 

--- a/technical/sqlite_export/index.md
+++ b/technical/sqlite_export/index.md
@@ -26,7 +26,7 @@ Is usually updated every hour. Download is a sqlite .db file.
 The GET request will return a redirect to a location on our storage server. If fetching automatically, make sure to follow the redirect (`Location:` header). E.g. with cURL:
 
 ```
-curl -L -u consumer_key:consumer_secret -O https://demo.rom.roqua.nl/api/v1/data_exports/download_sql
+curl -L -u consumer_key:consumer_secret -o output.sqlite https://demo.rom.roqua.nl/api/v1/data_exports/download_sql
 ```
 :::
 


### PR DESCRIPTION
## Summary

- The `Snapshot` component auto-generated `curl -X GET ...` for every endpoint, which is wrong for the SQL and CSV download endpoints — they return a redirect to storage and expect the client to follow it and write the body to disk.
- Drop the redundant `-X GET` for all GET requests, and when the snapshot's response has `Content-Disposition: attachment`, emit `-L -o "<filename>"` so the example actually works.
- Also fixes the hand-written cURL in `technical/sqlite_export/index.md` to use lowercase `-o output.sqlite` (capital `-O` doesn't accept a filename argument).

Before, on `/technical/sqlite_export/download_via_api`:
```
curl -X GET "https://api.example.com/api/v1/data_exports/download_sql" \
  -u "username:password"
```

After:
```
curl -L -o "demo.db" "https://api.example.com/api/v1/data_exports/download_sql" \
  -u "username:password"
```

## Test plan

- [x] Visited `/technical/sqlite_export/download_via_api` and confirmed the cURL tab renders `-L -o "demo.db"` with no `-X GET`.
- [x] Visited `/technical/csv_export/download_via_api` and confirmed the cURL tab renders `-L -o "demo_v201402_20140220105832.zip"`.
- [x] Visited `/technical/rest_api/dossier/responses` and confirmed:
  - GET examples render `curl "..."` (no `-X GET`)
  - POST examples still render `curl -X POST "..."`
  - PUT examples still render `curl -X PUT "..."`